### PR TITLE
Add EPUB3 docs to navigation bar

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -48,9 +48,9 @@
             <div class="navbar-item">Add-on Converters</div>
             {{!--
             <a class="navbar-item" href="{{{relativize (resolvePageURL 'pdf-converter::index.adoc')}}}">PDF</a>
-            <a class="navbar-item" href="{{{relativize (resolvePageURL 'epub3-converter::index.adoc')}}}">EPUB3</a>
             --}}
             <a class="navbar-item" href="{{{relativize (resolvePageURL 'reveal.js-converter::index.adoc')}}}">reveal.js <small>Ruby, JavaScript</small></a>
+            <a class="navbar-item" href="{{{relativize (resolvePageURL 'epub3-converter::index.adoc')}}}">EPUB3 <small>Ruby</small></a>
             <hr class="navbar-divider">
             <div class="navbar-item">Extended Syntax</div>
             {{#with (resolvePageURL 'diagram-extension::index.adoc')}}


### PR DESCRIPTION
@mojavelinux not sure whether you want this to be alphabetically sorted or by popularity. I went the latter route.