### PR TITLE
move docsearch footer outside of scrollable list (alternate approach)

### DIFF
--- a/src/css/vendor/docsearch.css
+++ b/src/css/vendor/docsearch.css
@@ -1,14 +1,16 @@
 @import "docsearch.js/dist/cdn/docsearch.css";
 
 .algolia-autocomplete .ds-dropdown-menu {
-  max-width: none;
-  min-width: auto;
-  width: 100%;
-  font-size: initial;
   background: var(--color-white);
   border: 1px solid var(--navbar-button-border-color);
   border-radius: var(--navbar-menu-border-radius);
   box-shadow: var(--navbar-menu-box-shadow);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(var(--viewport-height) - var(--navbar-height) - 4rem);
+  max-width: none;
+  min-width: auto;
+  width: 100%;
 }
 
 .algolia-autocomplete .ds-dropdown-menu::before {
@@ -16,17 +18,16 @@
   border-radius: 0;
 }
 
-.algolia-autocomplete .ds-dropdown-menu > :first-child {
-  max-height: calc(var(--viewport-height) - var(--navbar-height) - 4rem);
-  padding-bottom: 0;
-  border: none;
+.algolia-autocomplete .ds-dropdown-menu .ds-dataset-1 {
   background: none;
+  border: none;
   border-radius: 0;
   overscroll-behavior: none;
+  padding: 0 8px;
 }
 
 .algolia-autocomplete .ds-dropdown-menu .ds-suggestions {
-  margin-top: 4px;
+  margin: 4px 0 8px;
 }
 
 .algolia-autocomplete .algolia-docsearch-suggestion {
@@ -46,21 +47,35 @@
   font-weight: normal;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column::after {
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column::after {
   display: none;
 }
 
-.algolia-docsearch-suggestion--subcategory-column-text::after {
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column-text::after {
   content: "|";
   padding: 0 0.5em;
 }
 
-.algolia-autocomplete .ds-dropdown-menu > :first-child > :last-child {
-  margin-bottom: 8px;
+.algolia-autocomplete .ds-footer {
+  background-color: rgba(164, 167, 174, 0.1);
+  border-top: 1px solid rgba(225, 225, 225, 0.5);
+  padding: 10px 8px 8px;
+}
+
+.algolia-autocomplete .ds-footer::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+.algolia-autocomplete .algolia-docsearch-footer {
+  margin-top: 0;
+  width: 112px;
+  height: 16px;
 }
 
 @media screen and (min-width: 769px) {
-  .algolia-docsearch-suggestion--subcategory-column-text::after {
+  .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column-text::after {
     display: none;
   }
 }
@@ -70,7 +85,7 @@
     width: 28rem;
   }
 
-  .algolia-autocomplete .ds-dropdown-menu > :first-child {
+  .algolia-autocomplete .ds-dropdown-menu {
     max-height: calc(var(--viewport-height) - var(--navbar-height));
   }
 }

--- a/src/js/vendor/docsearch.bundle.js
+++ b/src/js/vendor/docsearch.bundle.js
@@ -24,7 +24,19 @@
       apiKey: config.apiKey,
       indexName: config.indexName,
       inputSelector: '#' + searchField.id + ' .query',
-      autocompleteOptions: { autoselect: false, debug: true, hint: false, minLength: 2 },
+      autocompleteOptions: {
+        autoselect: false,
+        debug: true,
+        hint: false,
+        minLength: 2,
+        templates: {
+          footer:
+            '<div class="ds-footer"><div class="algolia-docsearch-footer">' +
+            'Search by <a class="algolia-docsearch-footer--logo" href="https://www.algolia.com/docsearch" ' +
+            'target="_blank" rel="noopener">Algolia</a>' +
+            '</div></div>',
+        },
+      },
       algoliaOptions: baseAlgoliaOptions,
       transformData: protectHitOrder,
       queryHook:
@@ -45,6 +57,8 @@
     input.on('autocomplete:selected', onSuggestionSelected.bind(typeahead))
     input.on('autocomplete:updated', onResultsUpdated.bind(typeahead))
     dropdown._ensureVisible = ensureVisible
+    dropdown._show = show.bind(dropdown)
+    delete dropdown.datasets[0].templates.footer
     menu.off('mousedown.aa')
     menu.off('mouseenter.aa')
     menu.off('mouseleave.aa')
@@ -182,6 +196,12 @@
     e.isDefaultPrevented = function () {
       return true
     }
+  }
+
+  function show () {
+    this.$container.css('display', '')
+    this._redraw()
+    this.trigger('shown')
   }
 
   function clearSearch () {


### PR DESCRIPTION
This is an alternate approach to #109. Instead of moving the results panel to a designated slot, this approach wraps the children of .ds-dropdown-menu in a new div .ds-dropdown-panel. It works just as well as #109, but doesn't allow us to remove as many CSS workarounds. I've submitted for future reference, but we will probably go with #109 instead.