### PR TITLE
resolves #115 hide built-in arrow on summary element in Safari

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -92,6 +92,7 @@ button::-moz-focus-inner {
 summary {
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
+  outline: none;
 }
 
 table {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -657,6 +657,10 @@
   margin-bottom: 0.5rem;
 }
 
+.doc details > summary::-webkit-details-marker {
+  display: none;
+}
+
 .doc details > summary::before {
   content: "";
   border: solid transparent;


### PR DESCRIPTION
- hide built-in arrow on summary element in Safari
- remove outline from summary element in Safari