### PR TITLE
Update link to the browser extension documentation

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -81,7 +81,7 @@
             {{/with}}
             <hr class="navbar-divider">
             <div class="navbar-item">Text Editors / Viewers</div>
-            <a class="navbar-item" href="https://github.com/asciidoctor/asciidoctor-browser-extension#readme" target="_blank" rel="noopener">Browser Extension</a>
+            <a class="navbar-item" href="{{{relativize (resolvePageURL 'browser-extension::index.adoc')}}}" target="_blank" rel="noopener">Browser Extension</a>
             <a class="navbar-item" href="https://intellij-asciidoc-plugin.ahus1.de/docs" target="_blank" rel="noopener">IntelliJ Plugin</a>
           </div>
         </div>


### PR DESCRIPTION
The browser extension documentation is now part of docs.asciidoctor.org documentation site.