### PR TITLE
Disable text selection on the source toolbox

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -828,6 +828,7 @@
   font-size: calc(13 / var(--rem-base) * 1rem);
   line-height: 1;
   white-space: nowrap;
+  user-select: none;
 }
 
 .doc .listingblock:hover .source-toolbox {


### PR DESCRIPTION
Not perfect on Chrome but now it's possible to select the last character. In addition, the user cannot inadvertently select the language and/or the "copy to clipboard" title.


resolves #130