### PR TITLE
add prerelease banner to article page

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -27,6 +27,7 @@ site:
       url: '#'
       version: '5.2'
       displayVersion: '5.2'
+      prerelease: true
     - url: '#'
       version: '5.1'
       displayVersion: '5.1'

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -33,21 +33,18 @@
   margin: 1rem 0 0;
 }
 
-.doc > h1.page:first-child,
-.doc > .prerelease-banner + h1.page {
+.doc > h1.page {
   font-size: calc(36 / var(--rem-base) * 1rem);
   margin: 1.5rem 0;
 }
 
 @media screen and (min-width: 769px) {
-  .doc > h1.page:first-child,
-  .doc > .prerelease-banner + h1.page {
+  .doc > h1.page {
     margin-top: 2.5rem;
   }
 }
 
-.doc > h1.page:first-child + aside.toc.embedded,
-.doc > .prerelease-banner + h1.page + aside.toc.embedded {
+.doc > h1.page + aside.toc.embedded {
   margin-top: -0.5rem;
 }
 

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -33,19 +33,45 @@
   margin: 1rem 0 0;
 }
 
-.doc > h1.page:first-child {
+.doc > h1.page:first-child,
+.doc > .prerelease-banner + h1.page {
   font-size: calc(36 / var(--rem-base) * 1rem);
   margin: 1.5rem 0;
 }
 
 @media screen and (min-width: 769px) {
-  .doc > h1.page:first-child {
+  .doc > h1.page:first-child,
+  .doc > .prerelease-banner + h1.page {
     margin-top: 2.5rem;
   }
 }
 
-.doc > h1.page:first-child + aside.toc.embedded {
+.doc > h1.page:first-child + aside.toc.embedded,
+.doc > .prerelease-banner + h1.page + aside.toc.embedded {
   margin-top: -0.5rem;
+}
+
+.doc .prerelease-banner {
+  background: var(--admonition-background);
+  border-left: 4px solid var(--caution-color);
+  font-size: calc(16 / var(--rem-base) * 1rem);
+  margin: 1.5rem 0;
+  padding: 0.75rem 1rem;
+}
+
+.doc .prerelease-banner::before {
+  content: 'Prerelease';
+  display: inline-block;
+  background: var(--caution-color);
+  color: var(--caution-on-color);
+  border-radius: 0.25em;
+  font-size: calc(13 / var(--rem-base) * 1rem);
+  font-weight: var(--admonition-label-font-weight);
+  margin-right: 0.5em;
+  padding: 0.1em 0.4em;
+  text-transform: uppercase;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .doc > h2#name + .sectionbody {

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,4 +1,5 @@
 <article class="doc {{{page.component.name}}}">
+{{> prerelease-banner}}
 {{#with page.title}}
 <h1 class="page">{{{this}}}</h1>
 {{/with}}

--- a/src/partials/prerelease-banner.hbs
+++ b/src/partials/prerelease-banner.hbs
@@ -1,0 +1,6 @@
+{{#if page.componentVersion.prerelease}}
+<div class="prerelease-banner">
+  This documentation covers a prerelease version.
+  {{#each page.versions}}{{~#if (and (eq this.version @root.page.component.latestVersion.version) (not (eq this.version @root.page.version)))}} <a href="{{{relativize this.url}}}">View stable ({{./displayVersion}})</a>{{~/if~}}{{/each}}
+</div>
+{{/if}}

--- a/src/partials/prerelease-banner.hbs
+++ b/src/partials/prerelease-banner.hbs
@@ -1,6 +1,6 @@
 {{#if page.componentVersion.prerelease}}
 <div class="prerelease-banner">
-  This documentation covers a prerelease version.
-  {{#each page.versions}}{{~#if (and (eq this.version @root.page.component.latestVersion.version) (not (eq this.version @root.page.version)))}} <a href="{{{relativize this.url}}}">View stable ({{./displayVersion}})</a>{{~/if~}}{{/each}}
+  This documentation covers a prerelease version of the software.
+  {{#each page.versions}}{{~#if (and (eq this.version @root.page.component.latestVersion.version) (not (eq this.version @root.page.version)))}} You can view the <a href="{{{relativize this.url}}}">documentation for the stable version ({{./displayVersion}})</a>.{{~/if~}}{{/each}}
 </div>
 {{/if}}


### PR DESCRIPTION
Show a banner at the top of the article when page.componentVersion.prerelease is set, with a "View stable (x.y)" link pointing to the equivalent page in the latest stable version.

Resolves #137