### PR TITLE
resolves #145 add Asciidoctor Kroki entry to the Extensions menu (Extended Syntax)

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -55,8 +55,8 @@
             <hr class="navbar-divider">
             <div class="navbar-item">Extended Syntax</div>
             <a class="navbar-item" href="{{{relativize (resolvePageURL 'diagram-extension::index.adoc')}}}">Asciidoctor Diagram <small>Ruby</small></a>
+            <a class="navbar-item" href="{{{relativize (resolvePageURL 'kroki-extension::index.adoc')}}}">Asciidoctor Kroki <small>Ruby, JavaScript</small></a>
             {{!--
-            <a class="navbar-item" href="{{{relativize (resolvePageURL 'kroki-extension::index.adoc')}}}">Asciidoctor Kroki <small>JavaScript</small></a>
             <a class="navbar-item" href="#">Asciidoctor Chart</a>
             <a class="navbar-item" href="#">Asciidoctor bibtex</a>
             <div class="navbar-item">Feature Adapters</div>


### PR DESCRIPTION
This change enables the Asciidoctor Kroki entry in the Extensions menu, under the "Extended Syntax" section. The link was previously commented out. It now points to the `kroki-extension` component and the label mentions both Ruby and JavaScript since the extension is available for both.

Resolves https://github.com/asciidoctor/asciidoctor-docs-ui/issues/145

